### PR TITLE
Ensure hubapi docker container has updated packages before upgrade is is...

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ git clone https://github.com/PhyDaC/scoop-env
 cd scoop-env
 vagrant up
 ```
+Note: 64-bit guests in VirtualBox require VT-x support.  Ensure that VT-x support is enabled in the BIOS before installing 64-bit guests.
 
 A Fedora image is downloaded on the first run.  Please expect it to take time.
 
-Read `util/prosition.sh` to see how it:
+Read `util/provision.sh` to see how it:
 
 * Creates a second drive and join both as a volume group
 * Expands the logical volume and resize the filesystem

--- a/hubapi/Dockerfile
+++ b/hubapi/Dockerfile
@@ -22,7 +22,7 @@ RUN git clone https://github.com/PhyDaC/hubapi
 WORKDIR /app/hubapi
 
 # Install apps
-RUN apt-get install -y unzip lynx nodejs npm nano
+RUN apt-get update && apt-get install -y unzip lynx nodejs npm nano && apt-get clean
 
 # Remove any binaries that might have invalid ELF headers
 RUN rm -rf node-modules


### PR DESCRIPTION
Unless the apt-get package cache is updated, an 'apt-get install nodejs' call fails because the package requested is no longer present.  All calls to 'apt-get install' should be proceeded by an 'apt-get update'.   An 'apt-get clean' should be issued after installations to keep the docker container as small as possible.

The error is:
```
E: Failed to fetch http://http.debian.net/debian/pool/main/n/nodejs/nodejs_0.10.29~dfsg-1_amd64.deb  404  Not Found

E: Failed to fetch http://http.debian.net/debian/pool/main/u/unzip/unzip_6.0-12+b1_amd64.deb  404  Not Found

E: Failed to fetch http://http.debian.net/debian/pool/main/n/nodejs/nodejs-dev_0.10.29~dfsg-1_amd64.deb  404  Not Found

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Fetched 4783 kB in 19s (247 kB/s)
2015/01/12 19:54:14 The command [/bin/sh -c apt-get install -y unzip lynx nodejs npm nano] returned a non-zero code: 100
make: *** [build-hubapi] Error 1
```
